### PR TITLE
Check production env var before doing work

### DIFF
--- a/lib/jekyll_lunr_js_search/indexer.rb
+++ b/lib/jekyll_lunr_js_search/indexer.rb
@@ -52,6 +52,10 @@ module Jekyll
       # Index all pages except pages matching any value in config['lunr_excludes'] or with date['exclude_from_search']
       # The main content from each page is extracted and saved to disk as json
       def generate(site)
+        if ENV["PRODUCTION"] == "NO"
+          Jekyll.logger.info "Lunr:", 'Skipping search index...'
+          return
+        end
         Jekyll.logger.info "Lunr:", 'Creating search index...'
 
         @site = site


### PR DESCRIPTION
In the artsy blog we avoid doing long work when [not in a production environment](https://github.com/artsy/artsy.github.io/blob/source/Rakefile#L9-L31)

This is doing long work, so now we can skip it when you're just wanting to see your page updated.